### PR TITLE
Feat/inert attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ The `useMountTransition` hook returns two properties to handle the mounting and 
 
 ```tsx
 export function Sample(itemIsShown: boolean) {
-    const { showTransitionElement, withTransitionStyles } = useMountTransition({
+    const { showTransitionElement, transitionElementAttrs, withTransitionStyles } = useMountTransition({
       duration: 150,
       isShown: itemIsShown,
     });
 
     return (
       showTransitionElement ? (
-        <div className={withTransitionStyles ? styles.slideIn : ''}>
+        <div className={withTransitionStyles ? styles.slideIn : ''} {...transitionElementAttrs}>
           ...
         </div>
       ) : null;
@@ -59,7 +59,8 @@ export function Sample(itemIsShown: boolean) {
 
 ### Return
 
-| Prop                  | Type    | Description                                                                                       |
-| --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
-| showTransitionElement | boolean | This is the core prop to handle when and when not to render the transitioning element in the DOM. |
-| withTransitionStyles  | boolean | This prop determines when the transition styles are to be applied and removed.                    |
+| Prop                   | Type                        | Description                                                                                                                                                 |
+| ---------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| showTransitionElement  | boolean                     | This is the core prop to handle when and when not to render the transitioning element in the DOM.                                                           |
+| transitionElementAttrs | HTMLAttributes<HTMLElement> | An object of properties returned to the transitioning element. Currently, this handles `inert` values for improved accessibility during element transition. |
+| withTransitionStyles   | boolean                     | This prop determines when the transition styles are to be applied and removed.                                                                              |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-mount-transition",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "A simple React hook to transition an element in and out on mount.",
     "author": "Daniel Yuschick <daniel.yuschick@gmail.com>",
     "license": "MIT",

--- a/src/useMountTransition.hook.ts
+++ b/src/useMountTransition.hook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { HTMLAttributes, useEffect, useState } from 'react';
 
 interface MountTransitionProps {
     duration: number;
@@ -8,6 +8,7 @@ interface MountTransitionProps {
 export type MountTransitionHook = {
     showTransitionElement: boolean;
     withTransitionStyles: boolean;
+    transitionElementAttrs: HTMLAttributes<HTMLElement> & { inert?: string };
 };
 
 export const useMountTransition = ({
@@ -33,5 +34,8 @@ export const useMountTransition = ({
     return {
         showTransitionElement: hasTransitionedIn || isShown,
         withTransitionStyles: hasTransitionedIn && isShown,
+        transitionElementAttrs: {
+            inert: !isShown ? 'true' : undefined,
+        },
     };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
         "strict": true,
         "target": "es6"
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## 🔐 Closes

N/A

## 🚀 Changes

Adds `transitionElementAttrs` return from the hook to support `inert` HTML attribute.

## ⛳️ Testing

